### PR TITLE
[bugfix][issue]修改ritual脚本，修正docker-compose中logging键添加多次的问题

### DIFF
--- a/Ritual.sh
+++ b/Ritual.sh
@@ -177,7 +177,7 @@ function install_ritual_node() {
     echo "配置 infernet-anvil 禁止日志写入..."
     if [ -f ~/infernet-container-starter/deploy/docker-compose.yaml ]; then
         # 在 infernet-anvil 服务下添加 logging 配置
-        sed -i '/infernet-anvil:/a\    logging:\n      driver: "none"' ~/infernet-container-starter/deploy/docker-compose.yaml
+        sed -i '/^  infernet-anvil:/a\    logging:\n      driver: "none"' ~/infernet-container-starter/deploy/docker-compose.yaml
         echo "[提示] infernet-anvil 的日志写入已禁用。"
     else
         echo "[警告] 未找到 docker-compose.yaml 文件，跳过禁用 infernet-anvil 日志步骤。"


### PR DESCRIPTION
https://github.com/sdohuajia/Ritual/issues/1


执行前：
对应官方代码仓：
https://github.com/ritual-net/infernet-container-starter/blob/main/deploy/docker-compose.yaml

![image](https://github.com/user-attachments/assets/ae30fe6e-6893-4057-b802-9e62499bfe90)

sed命令：
改进点：使用^匹配  infernet-anvil:这一行  并且无法匹配image: ritualnetwork/infernet-anvil:1.0.0 这一行

sed -i  '/^  infernet-anvil:/a\    logging:\n      driver: "none"'   docker-compose.yaml

结果：
<img width="863" alt="1745291707627" src="https://github.com/user-attachments/assets/7cb4c5e7-46b8-4739-9027-029513b2944d" />
